### PR TITLE
Fix empty space after the News section

### DIFF
--- a/templates/pages/index.html.njk
+++ b/templates/pages/index.html.njk
@@ -44,7 +44,7 @@
     </div>
     <div class="section-video-text ttu mb4 tc">Impressions of JSConf EU 2018</div>
   </a>
-  <section class="section-cfs section-last">
+  <section class="section-cfs">
     <div class="grid">
       <div class="grid-item-full">
         <div class="section-ornament section-ornament--right">
@@ -65,8 +65,7 @@
       sortObjects('metadata.date', '2017-01-01', 'date') |
       reverse %}
 
-
-  <div class="section-news">
+  <div class="section-news section-last">
     <div class="grid">
       <div class="grid-item-full">
         <div class="section-ornament section-ornament--left">


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/11782/49326218-27938180-f54f-11e8-96cc-06734614cfe2.png)

After:
![image](https://user-images.githubusercontent.com/11782/49326213-10549400-f54f-11e8-92ea-28a2304329e5.png)
