### PR TITLE
Accept 3 or more dashes to deliminate frontmatter.

### DIFF
--- a/scripts/spreadsheet-import/index.js
+++ b/scripts/spreadsheet-import/index.js
@@ -285,14 +285,14 @@ async function main(params) {
 
 function extractFrontmatter(data, content) {
   let frontmatterFromContent;
-  if (!content.startsWith('----\n')) {
+  if (!/^----*\n/.test(content.trim())) {
     return;
   }
   let sepCount = 0;
   let yamlString = '';
   let rest = ''
   content.split('\n').forEach(line => {
-    if (line == '----') {
+    if (/^----*$/.test(line)) {
       sepCount++;
       return;
     }


### PR DESCRIPTION
Previously we only accepted exactly 4. Probably because that is what we have been generating for a few years.