### PR TITLE
Make the dash fix work for content that used `:file` in the URL.

### DIFF
--- a/scripts/spreadsheet-import/index.js
+++ b/scripts/spreadsheet-import/index.js
@@ -262,6 +262,12 @@ async function main(params) {
           });
         }
         if (metadata.filename) {
+          // Make all URLs explicit instead of interpolating filename
+          metadata.filename = metadata.filename.replace(/:file/, filename);
+          if (!/^\//.test(metadata.filename)) {
+            metadata.filename = `/${cpath}/${metadata.filename}`;
+          }
+
           metadata.filename = maybeUpdateDoubleDash(metadata.filename);
         }
 

--- a/scripts/spreadsheet-import/redirect.js
+++ b/scripts/spreadsheet-import/redirect.js
@@ -10,7 +10,7 @@ module.exports = function redirect(r) {
       JSON.stringify({
         "template": "pages/redirect.html.njk",
         "filename": r.from,
-        "redirectUrl": r.to,
+        "redirectUrl": r.to.replace(/\/index\.html/, '/'),
       }, null, '  '));
   console.info(`Redirect from '${ r.from }' to '${ r.to }' as '${ filename }'`);
 };


### PR DESCRIPTION
Makes all URLs in generated MD files explicit. That is probably better anyway.