### PR TITLE
Turn off lazyloading of SVGs icons.

### DIFF
--- a/templates/_macros.njk
+++ b/templates/_macros.njk
@@ -4,6 +4,8 @@
       <title id='title-{{ id }}'>{{ title }}</title>
     {% endif %}
     <image xlink:href="{{ contents.svg[id + '.svg'].url }}"
+        lazyload="off"
+        decoding="async"
         height="{{ height }}px"
         width="{{ width }}px"/>
   </svg>

--- a/templates/partials/speaker-picture.html.njk
+++ b/templates/partials/speaker-picture.html.njk
@@ -2,6 +2,7 @@
   <figure class="ma0 speaker-picture">
     <img
         lazyload="on"
+        decoding="async"
         src="{{ contents.images.cms[data.image.filename_square_1000].url }}"
         srcset="{{
           contents.images.cms[data.image.filename_square_200].url }} 200w, {{
@@ -14,6 +15,7 @@
   <figure class="ma0 speaker-picture">
     <img
         lazyload="on"
+        decoding="async"
         src="{{ contents.images.placeholder['speaker-placeholder-' + (data.firstname.codePointAt(0) % 6) + '.jpg'].url }}"
     alt="Photo of a bear used as a placeholder because of a missing image.">
   </figure>


### PR DESCRIPTION
And while we are at it, make decoding of many images async.

The lazyloading triggers a bug in Chrome https://bugs.chromium.org/p/chromium/issues/detail?id=846170#c23 Turning it off (and it isn't appropriate here anyway) as a workaround.