### PR TITLE
[Scholarship] Point to FAQ before apply button

### DIFF
--- a/contents/copy/scholarships/faq.md
+++ b/contents/copy/scholarships/faq.md
@@ -12,14 +12,6 @@ If you get selected for a scholarship _with travel support_, you will receive a 
 
 In case you get a _ticket-only_ scholarship, you will receive just a combo ticket to CSSconf/JSConf EU 2019.
 
-__How can I get an invitation letter for my visa?__
-
-Once you get selected for the scholarship, we will send you a form from which we will create an invitation letter for visa. This might take some time, so if your country has specific time restrictions on visas, please let us know in advance via [scholarship@jsconf.eu](mailto:scholarship@jsconf.eu?subject=Scholarship%20FAQ).
-
-__Can I apply for a scholarship again if I got one last year?__
-
-For the sake of fairness we don't give away a scholarship to the same person within 2 years, this means we won't consider anyone who has already received a scholarship for CSSconf/JSConf EU in 2017 and 2018.
-
 __How long are applications open for and when will I get feedback?__
 
 This depends on whether you need a [_visa to enter Germany_](https://www.auswaertiges-amt.de/en/einreiseundaufenthalt/visabestimmungen-node). We have two separate application timelines for people who need a visa and people who do not need a visa (i.e. Schengen area residents). The timelines are as follows:
@@ -27,8 +19,16 @@ This depends on whether you need a [_visa to enter Germany_](https://www.auswaer
 - __If you need a visa__: From 15th of November, 2018 until 30th of January, 2019. Our feedback for this application round will be provided by **Friday, 22nd February, 2019**.
 - __If you do not need a Visa__: From 15th of November, 2018 until 10th of March, 2019. Our feedback for this application round will be provided by **Sunday, 24th March, 2019**.
 
+__Can I apply for a scholarship again if I got one last year?__
+
+For the sake of fairness we don't give away a scholarship to the same person within 2 years, this means we won't consider anyone who has already received a scholarship for CSSconf/JSConf EU in 2017 and 2018.
+
 __Why are scholarship holders without a travel grant being charged 20 EUR per conference day?__
 
 This is a good and valid question. In the past we unfortunately experienced a small number of scholarship holders that neither informed us beforehand nor showed up at the conference. Therefore we had tickets left which we were not able to give to another scholarship applicant from the waiting list. Applicants who needed a visa and travel were not among this group since we are in contact with them the weeks before the conference to book travel and hotel. That's why we decided to take a small fee per conference day for the scholarships without travel grants, just to make sure that people who are not able to attend inform us on time. 
 
 The fee is refunded once you attend the conference or inform us on time (**until 2019, 29th May**) if you can not make it at all.
+
+__How can I get an invitation letter for my visa?__
+
+Once you get selected for the scholarship, we will send you a form from which we will create an invitation letter for visa. This might take some time, so if your country has specific time restrictions on visas, please let us know in advance via [scholarship@jsconf.eu](mailto:scholarship@jsconf.eu?subject=Scholarship%20FAQ).

--- a/contents/copy/scholarships/introduction.md
+++ b/contents/copy/scholarships/introduction.md
@@ -7,3 +7,5 @@ Anyone from an underrepresented group in tech is invited to apply for a scholars
 If you’ve always wanted to visit JSConf and/or CSSconf EU, but haven’t had the money or resources to, this is your chance! The Scholarship Program was made for you.
 
 ❤️ Granting these scholarships is made possible thanks to the wonderful people that buy Diversity Support Tickets, as well as the generous contributions made by our sponsors. More help is needed – talk to us if you’d like to get involved: [scholarship@jsconf.eu](mailto:scholarship@jsconf.eu?subject=Scholarship%20Program).
+
+__Before you apply, please make sure to have fully read the 👍 FAQ to learn about our deadlines and conditions.__


### PR DESCRIPTION
This PR does following:

- points to FAQ before apply button
- reorders FAQ questions

As soon as this is approved, I am going to copy the same for https://github.com/cssconf/2019.cssconf.eu.