### PR TITLE
Fix partial paint of page

### DIFF
--- a/templates/partials/topbar.html.njk
+++ b/templates/partials/topbar.html.njk
@@ -27,12 +27,8 @@
     </nav>
     <a href="{{ buyTicketsLink }}" class="btn btn--undefinedpurple topbar-cta buy-ticket">Buy ticket</a>
     <button id="topbar-toggle" type="button" class="topbar-toggle"
-        title="Toggle Navigation">
+        title="Toggle Navigation"
+        onclick="document.getElementById('topbar-nav').classList.toggle('topbar-nav--is-visible')">
     </button>
-    <!--
-    Changes to the script must be reflected in the CSP in default.html.njk
-    Use https://report-uri.com/home/hash to generate the new hash.
-    -->
-    <script>document.getElementById('topbar-toggle').onclick=function(){document.getElementById('topbar-nav').classList.toggle('topbar-nav--is-visible')}</script>
   </div>
 </div>


### PR DESCRIPTION
Chrome is issuing a paint when it sees the inline script in the page header. Converting it to an inline event handler instead. An inline handler is used to avoid uncanny valley.

Details: https://bugs.chromium.org/p/chromium/issues/detail?id=933035#c5