### PR TITLE
Don't render sponsor types count

### DIFF
--- a/templates/partials/sponsors-grid.html.njk
+++ b/templates/partials/sponsors-grid.html.njk
@@ -1,7 +1,7 @@
 {% set sponsorTypes = ['organizing', 'festival', 'main', 'supporting', 'community'] %}
 
 {% if page.metadata.allSponsors %}
-  {{ sponsorTypes.push('travel') }}
+  {% set sponsorTypes = ['organizing', 'festival', 'main', 'supporting', 'community', 'travel'] %}
 {% endif %}
 
 {% for sponsorType in sponsorTypes %}


### PR DESCRIPTION
As it turned out, `{{ sponsorTypes.push('travel') }}` printed the new length in the template.